### PR TITLE
Fix bug: should reset ResponseWriter status when reused

### DIFF
--- a/response_writer.go
+++ b/response_writer.go
@@ -35,6 +35,8 @@ type responseWriter struct {
 
 func (rw *responseWriter) reset(w http.ResponseWriter) {
 	rw.ResponseWriter = w
+	rw.status = 0
+	rw.size = 0
 }
 
 func (rw *responseWriter) WriteHeader(s int) {


### PR DESCRIPTION
Otherwise we will get incorrect c.Writer.Written()